### PR TITLE
update the workflow for gemm case

### DIFF
--- a/tools/common_lib/src/gemm.cpp
+++ b/tools/common_lib/src/gemm.cpp
@@ -81,7 +81,7 @@ std::vector<std::byte> dnnl_gemm_op::gemm(const bindings_t& bindings, opts_t opt
     {
         return opts.beta != 0.0f || opts.beta != 1.0f;
     };
-    if (opts.alpha != 1.0f ) {
+    if (opts.alpha != 1.0f || has_beta_scaling_factors() ) {
         po.append_eltwise(dnnl::algorithm::eltwise_linear, has_beta_scaling_factors() ? opts.alpha / opts.beta : opts.alpha , 0.0f);
     }
 
@@ -118,7 +118,7 @@ std::vector<std::byte> dnnl_gemm_op::gemm(const bindings_t& bindings, opts_t opt
     args.insert({ DNNL_ARG_DST, output_memory });
 
     std::size_t post_ops_idx = 0ull;
-    if (opts.alpha != 1)
+    if (opts.alpha != 1 || has_beta_scaling_factors())
     {
         post_ops_idx++;
     }

--- a/tools/common_lib/src/gemm.cpp
+++ b/tools/common_lib/src/gemm.cpp
@@ -69,17 +69,6 @@ std::vector<std::byte> dnnl_gemm_op::gemm(const bindings_t& bindings, opts_t opt
         return dnnl::memory(to_dnnl_mem_desc(opts.output_shape, opts.out_layout, opts.out_dt), engine);
     }();
 
-    /*dnnl::memory alpha_scale_memory = [&]()
-    {
-        const float alpha = opts.alpha / (opts.beta == 0.0f ? 1.0f : opts.beta);
-        return create_dnnl_memory(binding_t{ reinterpret_cast<const std::byte*>(&alpha), DataType::eFp32, DataLayout::eW, TensorShape{1, 0, 0, 0} }, engine);
-    }();
-
-    dnnl::memory beta_scale_memory = [&]()
-    {
-        return create_dnnl_memory(binding_t{ reinterpret_cast<const std::byte*>(&opts.beta), DataType::eFp32, DataLayout::eW, TensorShape{1, 0, 0, 0} }, engine);
-    }();*/
-
     dnnl::post_ops po{};
     dnnl::primitive_attr attrs{};
     if (opts.force_fp32_accumulator)
@@ -87,18 +76,13 @@ std::vector<std::byte> dnnl_gemm_op::gemm(const bindings_t& bindings, opts_t opt
         attrs.set_accumulation_mode(dnnl::accumulation_mode::strict);
     }
 
-    /*auto has_scaling_factors = [&]()
+    //add three post-ops below to handle the formula: beta*(alpha/beta*(A*B)+C))
+    auto has_beta_scaling_factors = [&]()
     {
-        return opts.alpha != 1.0f || opts.beta != 1.0f;
+        return opts.beta != 0.0f || opts.beta != 1.0f;
     };
-
-    if (has_scaling_factors())
-    {
-        attrs.set_scales_mask(DNNL_ARG_WEIGHTS, 0);
-    }*/
-    if (opts.alpha != 1.0f) {
-        po.append_eltwise(dnnl::algorithm::eltwise_linear, opts.alpha/opts.beta, 0.0f);
-
+    if (opts.alpha != 1.0f ) {
+        po.append_eltwise(dnnl::algorithm::eltwise_linear, has_beta_scaling_factors() ? opts.alpha / opts.beta : opts.alpha , 0.0f);
     }
 
     if (input_c_memory)
@@ -106,12 +90,8 @@ std::vector<std::byte> dnnl_gemm_op::gemm(const bindings_t& bindings, opts_t opt
         po.append_binary(dnnl::algorithm::binary_add, input_c_memory.get_desc());
     }
 
-    //if (has_scaling_factors())
-    //{
-    //    po.append_binary(dnnl::algorithm::binary_mul, beta_scale_memory.get_desc());
-    //}
-    if (opts.beta != 1.0f) {
-        //po.append_sum(opts.beta);
+    if (has_beta_scaling_factors()) {
+
         po.append_eltwise(dnnl::algorithm::eltwise_linear, opts.beta, 0.0f);
     }
 
@@ -125,7 +105,6 @@ std::vector<std::byte> dnnl_gemm_op::gemm(const bindings_t& bindings, opts_t opt
     dnnl::matmul::primitive_desc matmul_desc(engine,
         input_a_memory.get_desc(),
         input_b_memory.get_desc(),
-        //{}, // we dont use bias for c_tensir
         output_memory.get_desc(),
         attrs
     );
@@ -139,18 +118,19 @@ std::vector<std::byte> dnnl_gemm_op::gemm(const bindings_t& bindings, opts_t opt
     args.insert({ DNNL_ARG_DST, output_memory });
 
     std::size_t post_ops_idx = 0ull;
+    if (opts.alpha != 1)
+    {
+        post_ops_idx++;
+    }
     if (input_c_memory)
     {
         args.insert({DNNL_ARG_ATTR_MULTIPLE_POST_OP(post_ops_idx) | DNNL_ARG_SRC_1, input_c_memory});
         post_ops_idx++;
     }
-
-    /*if (has_scaling_factors())
+    if (has_beta_scaling_factors())
     {
-        args.insert({ DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, alpha_scale_memory });
-        args.insert({ DNNL_ARG_ATTR_MULTIPLE_POST_OP(post_ops_idx) | DNNL_ARG_SRC_1, beta_scale_memory });
         post_ops_idx++;
-    }*/
+    }
 
     for (int i = 0; i < opts.execution_iterations; i++)
     {

--- a/tools/common_lib/src/gemm.cpp
+++ b/tools/common_lib/src/gemm.cpp
@@ -125,7 +125,7 @@ std::vector<std::byte> dnnl_gemm_op::gemm(const bindings_t& bindings, opts_t opt
     dnnl::matmul::primitive_desc matmul_desc(engine,
         input_a_memory.get_desc(),
         input_b_memory.get_desc(),
-        {}, // we dont use bias for c_tensir
+        //{}, // we dont use bias for c_tensir
         output_memory.get_desc(),
         attrs
     );

--- a/tools/common_lib/src/gemm.cpp
+++ b/tools/common_lib/src/gemm.cpp
@@ -97,7 +97,7 @@ std::vector<std::byte> dnnl_gemm_op::gemm(const bindings_t& bindings, opts_t opt
         attrs.set_scales_mask(DNNL_ARG_WEIGHTS, 0);
     }*/
     if (opts.alpha != 1.0f) {
-        po.append_eltwise(dnnl::algorithm::eltwise_linear, opts.alpha, 0.0f);
+        po.append_eltwise(dnnl::algorithm::eltwise_linear, opts.alpha/opts.beta, 0.0f);
 
     }
 
@@ -110,8 +110,9 @@ std::vector<std::byte> dnnl_gemm_op::gemm(const bindings_t& bindings, opts_t opt
     //{
     //    po.append_binary(dnnl::algorithm::binary_mul, beta_scale_memory.get_desc());
     //}
-    if (opts.beta != 0.0f) {
-        po.append_sum(opts.beta);
+    if (opts.beta != 1.0f) {
+        //po.append_sum(opts.beta);
+        po.append_eltwise(dnnl::algorithm::eltwise_linear, opts.beta, 0.0f);
     }
 
     if (opts.activation.type != ActivationType::eUnknown)

--- a/tools/common_lib/src/gemm.cpp
+++ b/tools/common_lib/src/gemm.cpp
@@ -69,7 +69,7 @@ std::vector<std::byte> dnnl_gemm_op::gemm(const bindings_t& bindings, opts_t opt
         return dnnl::memory(to_dnnl_mem_desc(opts.output_shape, opts.out_layout, opts.out_dt), engine);
     }();
 
-    dnnl::memory alpha_scale_memory = [&]()
+    /*dnnl::memory alpha_scale_memory = [&]()
     {
         const float alpha = opts.alpha / (opts.beta == 0.0f ? 1.0f : opts.beta);
         return create_dnnl_memory(binding_t{ reinterpret_cast<const std::byte*>(&alpha), DataType::eFp32, DataLayout::eW, TensorShape{1, 0, 0, 0} }, engine);
@@ -78,7 +78,7 @@ std::vector<std::byte> dnnl_gemm_op::gemm(const bindings_t& bindings, opts_t opt
     dnnl::memory beta_scale_memory = [&]()
     {
         return create_dnnl_memory(binding_t{ reinterpret_cast<const std::byte*>(&opts.beta), DataType::eFp32, DataLayout::eW, TensorShape{1, 0, 0, 0} }, engine);
-    }();
+    }();*/
 
     dnnl::post_ops po{};
     dnnl::primitive_attr attrs{};
@@ -87,7 +87,7 @@ std::vector<std::byte> dnnl_gemm_op::gemm(const bindings_t& bindings, opts_t opt
         attrs.set_accumulation_mode(dnnl::accumulation_mode::strict);
     }
 
-    auto has_scaling_factors = [&]()
+    /*auto has_scaling_factors = [&]()
     {
         return opts.alpha != 1.0f || opts.beta != 1.0f;
     };
@@ -95,6 +95,10 @@ std::vector<std::byte> dnnl_gemm_op::gemm(const bindings_t& bindings, opts_t opt
     if (has_scaling_factors())
     {
         attrs.set_scales_mask(DNNL_ARG_WEIGHTS, 0);
+    }*/
+    if (opts.alpha != 1.0f) {
+        po.append_eltwise(dnnl::algorithm::eltwise_linear, opts.alpha, 0.0f);
+
     }
 
     if (input_c_memory)
@@ -102,9 +106,12 @@ std::vector<std::byte> dnnl_gemm_op::gemm(const bindings_t& bindings, opts_t opt
         po.append_binary(dnnl::algorithm::binary_add, input_c_memory.get_desc());
     }
 
-    if (has_scaling_factors())
-    {
-        po.append_binary(dnnl::algorithm::binary_mul, beta_scale_memory.get_desc());
+    //if (has_scaling_factors())
+    //{
+    //    po.append_binary(dnnl::algorithm::binary_mul, beta_scale_memory.get_desc());
+    //}
+    if (opts.beta != 0.0f) {
+        po.append_sum(opts.beta);
     }
 
     if (opts.activation.type != ActivationType::eUnknown)
@@ -137,12 +144,12 @@ std::vector<std::byte> dnnl_gemm_op::gemm(const bindings_t& bindings, opts_t opt
         post_ops_idx++;
     }
 
-    if (has_scaling_factors())
+    /*if (has_scaling_factors())
     {
         args.insert({ DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, alpha_scale_memory });
         args.insert({ DNNL_ARG_ATTR_MULTIPLE_POST_OP(post_ops_idx) | DNNL_ARG_SRC_1, beta_scale_memory });
         post_ops_idx++;
-    }
+    }*/
 
     for (int i = 0; i < opts.execution_iterations; i++)
     {

--- a/tools/common_lib/src/gemm.h
+++ b/tools/common_lib/src/gemm.h
@@ -1003,13 +1003,9 @@ public:
             }
 
             // alpha
-            // if (params_.alpha != 1.0f) {
-            //     ops.append_eltwise(dnnl::algorithm::eltwise_linear, params_.alpha, 0.0f);
-            // }
             if (params_.alpha != 1.0f)
             {
-               ops.append_eltwise(dnnl::algorithm::eltwise_linear, params_.alpha/params_.beta, 0.0f);
-               //attr.set_scales_mask(DNNL_ARG_WEIGHTS, 0);  // alpha / beta
+               ops.append_eltwise(dnnl::algorithm::eltwise_linear, has_beta_scaling_factors() ? params_.alpha / params_.beta : params_.alpha , 0.0f);
             }
 
             if (has_c_tensor())
@@ -1017,14 +1013,8 @@ public:
                 ops.append_binary(dnnl::algorithm::binary_add, input_c_memory_desc_.value());
             }
 
-            // beta
-            // if (params_.beta != 0.0f) {
-            //     ops.append_sum( params_.beta );
-            // }
-            if (params_.beta != 1.0f)
+            if (has_beta_scaling_factors())
             {
-                // ops.append_binary(dnnl::algorithm::binary_mul, 
-                //     to_dnnl_mem_desc(TensorShape{ 1, 0, 0, 0 }, DataLayout::eW, DataType::eFp32));
                 ops.append_eltwise(dnnl::algorithm::eltwise_linear, params_.beta, 0.0f);
             }
 
@@ -1041,7 +1031,6 @@ public:
         dnnl::matmul::primitive_desc matmul_desc(dnnl_engine_,
             input_a_memory_desc_,
             input_b_memory_desc_,
-           // dnnl::memory::desc{},  // we dont use bias for C Tensor, we use binary add pos-
             output_memory_desc_,
             attr
         );
@@ -1051,10 +1040,6 @@ public:
         const auto persistent_resource_size = [&]()
         {
             std::size_t ret = 0ull;
-          /*  if (has_scaling_factors())
-            {
-                ret += 2 * sizeof(float);
-            }*/
 
             if (params_.b_managed)
             {
@@ -1106,19 +1091,6 @@ public:
             reorder_input_c_ = dnnl::reorder(reorder_desc);
         }
 
-        /*if (has_scaling_factors())
-        {
-            const char* code_string =
-                "__attribute__((reqd_work_group_size(1, 1, 1))) "
-                "__kernel void copy_alphabeta(__global float* output, float alpha, float beta) "
-                "{"
-                "output[0] = alpha;"
-                "output[1] = beta;"
-                "}";
-
-            copy_alpha_shader_ = device_.create_pipeline_state_object("copy_alphabeta", code_string, std::strlen(code_string), "", UMD_SHADER_LANGUAGE::eOCL_STATELESS);
-            assert(copy_alpha_shader_);
-        }*/
     }
 
     std::uint32_t get_total_descriptor_count()override
@@ -1162,20 +1134,6 @@ public:
         std::size_t rsc_idx = 0;
         auto umd_persistent_mem = persistent_buffer_ ? iumd::custom_metacommand::UmdD3d12Memory(gpu_handles[rsc_idx++]) : iumd::custom_metacommand::UmdD3d12Memory{};
         std::size_t persistent_mem_offset = 0;
-
-        //if (has_scaling_factors())
-        //{
-        //    // hack for oneDNNL to have OneDNNL aligned with DirectML!
-        //    const float beta = has_c_tensor() ? params_.beta : 1.0f;
-        //    const float alpha = params_.alpha / beta;
-
-        //    copy_alpha_shader_->set_kernel_arg(0, &umd_persistent_mem);
-        //    copy_alpha_shader_->set_kernel_arg(1, iumd::IUMDPipelineStateObject::ScalarArgType{ sizeof(float), &alpha });
-        //    copy_alpha_shader_->set_kernel_arg(2, iumd::IUMDPipelineStateObject::ScalarArgType{ sizeof(float), &beta });
-        //    cmd.dispatch(copy_alpha_shader_.get(), { 1, 1, 1 }, { 1, 1, 1 });
-
-        //    persistent_mem_offset += 2 * sizeof(float);
-        //}
 
         // weights reorder
         if (reorder_input_b_)
@@ -1272,22 +1230,10 @@ public:
         dnnl::memory input_memory = create_dnnl_memory(input_a_memory_desc_, umd_input_a_memory_);
 
         std::size_t persistent_mem_offset = 0;
-       /* dnnl::memory alpha_factor_memory{};
-        dnnl::memory beta_factor_memory{};
-        if (has_scaling_factors())
-        {
-            alpha_factor_memory = create_dnnl_memory(dnnl_utils::to_dnnl_mem_desc(TensorShape(1, 0, 0, 0), DataLayout::eW, params_.dt), umd_alpha_beta_memory_, 0ull);
-            beta_factor_memory = create_dnnl_memory(dnnl_utils::to_dnnl_mem_desc(TensorShape(1, 0, 0, 0), DataLayout::eW, params_.dt), umd_alpha_beta_memory_, sizeof(float));
-            persistent_mem_offset += 2 * sizeof(float);
-        }*/
+     
         dnnl::memory input_b_memory = [&]()
         {
             std::size_t offset = 0ull;
-          /*  if (reorder_input_b_ && has_scaling_factors())
-            {
-                offset = persistent_mem_offset;
-                persistent_mem_offset += input_b_memory_desc_.get_size();
-            }*/
             return create_dnnl_memory(input_b_memory_desc_, umd_input_b_memory_, offset);
         }();
 
@@ -1312,18 +1258,21 @@ public:
         args.insert({ DNNL_ARG_SRC, input_memory });
         args.insert({ DNNL_ARG_WEIGHTS, input_b_memory });
         std::size_t post_ops_idx = 0ull;
+        if(params_.alpha!=1)
+        {
+            post_ops_idx++;
+        }
+
         if (input_c_memory)
         {
             args.insert({ DNNL_ARG_ATTR_MULTIPLE_POST_OP(post_ops_idx) | DNNL_ARG_SRC_1, input_c_memory });
             post_ops_idx++;
         }
 
-      /*  if (has_scaling_factors())
+        if(has_beta_scaling_factors())
         {
-            args.insert({ DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, alpha_factor_memory });
-            args.insert({ DNNL_ARG_ATTR_MULTIPLE_POST_OP(post_ops_idx) | DNNL_ARG_SRC_1, beta_factor_memory });
             post_ops_idx++;
-        }*/
+        }
 
         if (scratchpad_memory_desc_)
         {
@@ -1385,11 +1334,12 @@ private:
     };
 
 private:
-    bool has_scaling_factors() const
+    bool has_beta_scaling_factors() const
     {
-        // OneDNNL has a bit different GEMM API defintion
-        // we will pass alpha as alpha/beta, so here we need to check for both params
-        return params_.alpha != 1.0f || params_.beta != 1.0f;
+        // OneDNNL has a bit different GEMM API defintion: alpha*A*B + beta*C
+        // DirectML: beta*(alpha/beta*(A*B)+C))
+        // we will pass alpha as alpha/beta if beta value is effective
+         return params_.beta != 0.0f || params_.beta != 1.0f;
     }
 
     bool has_c_tensor() const

--- a/tools/common_lib/src/gemm.h
+++ b/tools/common_lib/src/gemm.h
@@ -1041,7 +1041,7 @@ public:
         dnnl::matmul::primitive_desc matmul_desc(dnnl_engine_,
             input_a_memory_desc_,
             input_b_memory_desc_,
-            dnnl::memory::desc{},  // we dont use bias for C Tensor, we use binary add pos-
+           // dnnl::memory::desc{},  // we dont use bias for C Tensor, we use binary add pos-
             output_memory_desc_,
             attr
         );

--- a/tools/common_lib/src/gemm.h
+++ b/tools/common_lib/src/gemm.h
@@ -1003,7 +1003,7 @@ public:
             }
 
             // alpha
-            if (params_.alpha != 1.0f)
+            if (params_.alpha != 1.0f || has_beta_scaling_factors())
             {
                ops.append_eltwise(dnnl::algorithm::eltwise_linear, has_beta_scaling_factors() ? params_.alpha / params_.beta : params_.alpha , 0.0f);
             }
@@ -1258,7 +1258,7 @@ public:
         args.insert({ DNNL_ARG_SRC, input_memory });
         args.insert({ DNNL_ARG_WEIGHTS, input_b_memory });
         std::size_t post_ops_idx = 0ull;
-        if(params_.alpha!=1)
+        if(params_.alpha!=1 || has_beta_scaling_factors())
         {
             post_ops_idx++;
         }

--- a/tools/common_lib/src/gemm.h
+++ b/tools/common_lib/src/gemm.h
@@ -1003,14 +1003,14 @@ public:
             }
 
             // alpha
-            if (params_.alpha != 1.0f) {
-                ops.append_eltwise(dnnl::algorithm::eltwise_linear, params_.alpha, 0.0f);
+            // if (params_.alpha != 1.0f) {
+            //     ops.append_eltwise(dnnl::algorithm::eltwise_linear, params_.alpha, 0.0f);
+            // }
+            if (params_.alpha != 1.0f)
+            {
+               ops.append_eltwise(dnnl::algorithm::eltwise_linear, params_.alpha/params_.beta, 0.0f);
+               //attr.set_scales_mask(DNNL_ARG_WEIGHTS, 0);  // alpha / beta
             }
-            //if (has_scaling_factors())
-            //{
-            //    
-            //    attr.set_scales_mask(DNNL_ARG_WEIGHTS, 0);  // alpha / beta
-            //}
 
             if (has_c_tensor())
             {
@@ -1018,14 +1018,15 @@ public:
             }
 
             // beta
-            if (params_.beta != 0.0f) {
-                ops.append_sum( params_.beta );
-            }
-            /*if (has_scaling_factors())
+            // if (params_.beta != 0.0f) {
+            //     ops.append_sum( params_.beta );
+            // }
+            if (params_.beta != 1.0f)
             {
-                ops.append_binary(dnnl::algorithm::binary_mul, 
-                    to_dnnl_mem_desc(TensorShape{ 1, 0, 0, 0 }, DataLayout::eW, DataType::eFp32));
-            }*/
+                // ops.append_binary(dnnl::algorithm::binary_mul, 
+                //     to_dnnl_mem_desc(TensorShape{ 1, 0, 0, 0 }, DataLayout::eW, DataType::eFp32));
+                ops.append_eltwise(dnnl::algorithm::eltwise_linear, params_.beta, 0.0f);
+            }
 
             if (params_.activation.type != ActivationType::eUnknown)
             {

--- a/tools/cross_runner/src/main.cpp
+++ b/tools/cross_runner/src/main.cpp
@@ -204,7 +204,7 @@ int main()
         }
         else if (opts.node_type == NodeType::eConvDml)
         {
-            node = std::make_unique<ConvolutionDirectMLDispatcher>(std::move(opts.conv_opts), false,
+            node = std::make_unique<ConvolutionDirectMLDispatcher>(std::move(opts.conv_opts), true,
                 d3d12_device.Get(), dml_device.Get(), dml_command_recorder.Get(), command_list.Get());
         }
         else if (opts.node_type == NodeType::eConvCm)

--- a/tools/cross_runner/src/main.cpp
+++ b/tools/cross_runner/src/main.cpp
@@ -204,7 +204,7 @@ int main()
         }
         else if (opts.node_type == NodeType::eConvDml)
         {
-            node = std::make_unique<ConvolutionDirectMLDispatcher>(std::move(opts.conv_opts), true,
+            node = std::make_unique<ConvolutionDirectMLDispatcher>(std::move(opts.conv_opts), false,
                 d3d12_device.Get(), dml_device.Get(), dml_command_recorder.Get(), command_list.Get());
         }
         else if (opts.node_type == NodeType::eConvCm)


### PR DESCRIPTION
DirectML will allocate two memory and pass to driver, c_memory and out_memory. We have no chance to use c_memory as the output memory in driver. 
So we have to use the following post-ops to handle beta*(alpha/beta*(A*B)+C)). It can also help improve the performance because the copy kernel for alpha and beta is removed from the previous code.
```
elementwise_linear with alpha/beta 
binary_add with C tensor
elementwise_linear with beta
```