### PR TITLE
Change GEMM input transposition API

### DIFF
--- a/tools/common_lib/src/gemm.h
+++ b/tools/common_lib/src/gemm.h
@@ -827,8 +827,8 @@ public:
         , d3d12_device_(d3d12_device)
     {
         
-        uint32_t quant_param_h = params_.b_transposed ? params_.shape_b.h : params_.shape_b.w;
-        uint32_t quant_param_w = params_.b_transposed ? params_.shape_b.w / params_.block_size : params_.shape_b.h / params_.block_size;
+        uint32_t quant_param_h = params_.shape_b.w;
+        uint32_t quant_param_w = params_.shape_b.h / params_.block_size;
 
         params_.shape_scale = TensorShape(params_.shape_b.n, params_.shape_b.c, quant_param_h, quant_param_w);
         params_.shape_zeropoint = TensorShape(params_.shape_b.n, params_.shape_b.c, quant_param_h, quant_param_w);
@@ -1141,8 +1141,8 @@ protected:
         TensorShape ret{};
         ret.n = get_batch();
         ret.c = get_channels();
-        ret.h = params_.b_transposed ? params_.shape_b.h : params_.shape_b.w;
-        ret.w = params_.b_transposed ? params_.shape_b.w / params_.block_size : params_.shape_b.h / params_.block_size;
+        ret.h = params_.shape_b.w;
+        ret.w = params_.shape_b.h / params_.block_size;
         return ret;
     }
         
@@ -1158,17 +1158,17 @@ protected:
 
     std::uint32_t get_M() const
     {
-        return params_.a_transposed ? params_.shape_a.w : params_.shape_a.h;
+        return params_.shape_a.h;
     }
 
     std::uint32_t get_K() const
     {
-        return params_.a_transposed ? params_.shape_a.h : params_.shape_a.w;
+        return params_.shape_a.w;
     }
 
     std::uint32_t get_N() const
     {
-        return params_.b_transposed ? params_.shape_b.h : params_.shape_b.w;
+        return params_.shape_b.w;
     }
 
 protected:
@@ -1644,7 +1644,7 @@ protected:
     {
         if (params_.type == GemmType::GemmType_AB || params_.type == GemmType::GemmType_SV_S_QKV || params_.type == GemmType::GemmType_SV_S_KV)
         {
-            return params_.b_transposed ? params_.shape_b.h : params_.shape_b.w;
+            return params_.shape_b.w;
         }
         else if (params_.type == GemmType::GemmType_QK_QKV)
         {

--- a/tools/common_lib/src/gemm.h
+++ b/tools/common_lib/src/gemm.h
@@ -534,8 +534,8 @@ public:
         dml::TensorDesc::Dimensions dimensions_1;
         dimensions_1.push_back(shape_b.n);
         dimensions_1.push_back(shape_b.c);
-        dimensions_1.push_back(shape_b.h);
-        dimensions_1.push_back(shape_b.w);
+        dimensions_1.push_back(b_transposed ? shape_b.w : shape_b.h); // to make cmd arguments have normal matrix with transpose internal to each dispatcher
+        dimensions_1.push_back(b_transposed ? shape_b.h : shape_b.w); // to make cmd arguments have normal matrix with transpose internal to each dispatcher
         dml::TensorDesc desc_input_1 = { quantized_data_type, b_managed ? DML_TENSOR_FLAG_OWNED_BY_DML : DML_TENSOR_FLAG_NONE, dimensions_1 };
         input_1_ = dml::InputTensor(graph_, 1, desc_input_1);
 


### PR DESCRIPTION
The new API expects logical input shapes to be used rather than the physical ones, with transposition being done on the back end and confirmed through DDI logs.